### PR TITLE
Conditional automated deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,20 @@ branches:
   - gh-pages
   - dev
 script:
+  - echo $TRAVIS_BRANCH
+  - echo $TRAVIS_PULL_REQUEST
 # This should detect the branch and run the correct build script
   - |
     if [ "$TRAVIS_BRANCH" = "dev" ]; then
+      echo "Building DEV";
       bundle exec jekyll build --config _config.yml,_config_dev.yml;
     fi
   - |
     if [ "$TRAVIS_BRANCH" = "gh-pages" &&  "$TRAVIS_PULL_REQUEST" == "false" ]; then
+      echo "Building LIVE";
       bundle exec jekyll build;
     fi
+
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_d15196a1bbe0_key -iv $encrypted_d15196a1bbe0_iv
   -in deploy_rsa.enc -out /tmp/deploy_rsa -d
@@ -31,16 +36,20 @@ before_deploy:
 - chmod 600 /tmp/deploy\_rsa
 - ssh-add /tmp/deploy\_rsa
 - echo -e "Host $DEPLOY_HOST\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+
 deploy:
 # DEV server deploy
   - provider: script
     skip_cleanup: true
     script: rsync -r --quiet --delete-after _site/* $DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_DIRECTORY
     on:
+      repo: levelupcc/level-up
       branch: dev
-# LIVE server deploy
+      condition: $TRAVIS_BRANCH = dev # DEV server deploy
   - provider: script
     skip_cleanup: true
     script: rsync -r --quiet --delete-after _site/* $DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_DIRECTORY_LIVE
     on:
+      repo: levelupcc/level-up
       branch: gh-pages
+      condition: $TRAVIS_BRANCH = gh-pages # LIVE server deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
 - 2.5
 env:
@@ -7,11 +8,16 @@ env:
   - secure: Sa6LOginTeDQNA0qld+KCu9FkRYP2JG8pWS08mDMZ5k4QxkGQHyniSiM/A/Hg5jqQsri3EEbLTgxal+XKLfvxYuRn9h0h17MzbGTvB2mcbvdnL90bLeWKFGYyqziJOuiHmlCzg0OaLFwg52OihxPOysPXCCZ0sp4DlK9yjpbH0BKD/J9b7I1IXOErhhZPAFthxn6Wh2S5TBuYqpVu1X1TdOKAKI/GYONknp4ESyqEXU5KQT9dtkhONOtcBHt8NgqR4q4mo5ILtYQLwr/W/77QIz6EJ6zzQWByqJBODJDclBQ6G/LDnLCy64CoM/l/DGk0Ksntqn8cYHTRiIB/V2rp8mgKPqEQQ2gItMzPFwEzsXDPNg9qFWQTSNJOMUM30FcxCkp81+o4mFG+yzMn/eF9S6Bx/7tDVCSlm0xEkuFv/pWCXtjVTSMe2mPBDqX0wG2otGil7wp5dKl2V8GnAnzSdb08haUD6CXWfC7sfBs3QudpV6krZovGzqblRoRqG8xpMUowOYzyjBK3wWNNAF1ZUApX1V/JHQHirWcPoIbe0mY2MmQ6xmO8hskeGoWJm6nrljW95U4ouxFheVfML/VeBMI5n9q5+zAscCXmjoM+PYih8N6/7SvSZKyC70aC7svSFjEcGGdj1sksGEdOyIi/grw1erc0QjjkFQKFu76src=
   - secure: PztS+tkL/jsRySl+y4YRZY1SDfXRgWsjQwbUW+oiKB7Lt1K7Figxa8bzlK21EssjOw1peoX7uLtBY37AJ2f6bD52kt5GmT5Vp4osuA/ko6NY8h0PdSlF2AmpK0nZddqOrnuh1YpV2hapn8uHXsSz6RceADsKUKBV20Mwes6X6583+DnVTNJywpvv8w3vRyefUlzjRn2+GIDmyemE898wZEpDvTAzhkEU+qlwAOP6TjT7t4bmrsXKuuCAozUwhA7bHiOEoEshFynUCLALZ6BrMOtcmDONWdgJwNlRGn9d+8WJl/1cwF1BeVztC0oLmgWaDncGM9oLCrdtssweMCfLT+9CdiGv7loifzXG+vuRPt11wmHp2i3dPplwglhFMKeThI26nKM/ooHbLKWp2HwjTGdPtXdPugXhKmAqY6lUm9MUdku5Y9szbSH/fHhc570EnvxMgJnHMe6n+30hrZXCZGqKEZjNJUq5KURd0/KvJmLDqZIlmo0c87vBaWCfKZ5WYin/vjN18HNvzqrAI4lFMZq2ZHtEVxt+ApYwDE621Xm7yWhVubgr5xM+CJXC471jOjzXpW+prUC/dr1mDM3OfNGCxEFz5n1rNTtcgoT8Yp+bgWpdmX9Rrn4j5Y4tKcywxsDG4rh8oTp+pAC7T+A1Qya257p0Qw1jX9jP+P8aMRM=
   - secure: gc5pIWAi/topa/ca2vUsCJKI1GsyJHhpgm3dr5x+Lthf6dvTXSLpcKW7r3AHvqofgrACzqI35FOtZv9/ggHfKZfB++CGHjC/vfEGrd9jDEYFbBPuEkxh8kM7skm/SxuARpXMCJ0UVjDwvL0hLPfrU6ys4b6reF9KMRlDKjz5NRd031FCD69IqVIACYPRr0B2MJURJLVhSn5ySQmXlL9e83uVjy0EYwRDI3cv1usVoBWaNa8gJOvWLZCOUVMbZyO6JiSI5YnvpN8A4LhStIW8ct2GCixMxDHsaxgYSWU9nlCpYd2uwBlsiha1B6mQ+nXQtB5jtZ/r7JO29pBCOegIZ386I3unk/6KIHgszyUKY/gybj9KpisXSj/rpPTY3iUxbKO/2zG2ZEKKRZtnUlqTdfg6oPsBW648j5McQ+FJLXMu6lsoywxnHOEbEgbpnSFTtP4Lyti8vN8lDxr9i21u5OcZ00YKO4+PSFKECWEksyB7z14nI60Gzqp4insjThSO2S7USqyIA7AFOhGKqnquCAZPjX+eOo2ISwyjzfmJnvTHySZumqoU5MZZDjobXI9dC1eEDYweXhm1/alx96fMViKvjince5AcenPJjnrR13Y8BZNGQrZqjYNJ83xi5IzZoICxVvBB2PYsLykP0b98AGQzSKqR5cRZncCf4Zf6nrk=
+  - secure: kvrV5SI+qZ/iPKayamFilSLpEwes8kLdVTntwoasO+dWTpMWd77NDml68fv2F7hBIXe3wCzvQtC0w52Y56Pu/UNBoOB+UBPRwKkb9N4hSVg1bAx3Yn/AIPAK6LHnL4qC3mi8uXtnoMVKXAo94xIgIj2k/mIbxtp7QzDoOiTjceFJvp28yFx51lb26Uw43BTaDQKdqZhojlEwya9mtjDlqPIT5jxW3RgpiQu7TAb0jAiryXLSMx/Sl+N+iedqEhmyfsp6FnTTNBeu2b23LloSbQGs6OMhaScDARTijurGb2eczwSc/Z8KiAMG+x2bxR0aJtUWTssDjzM/ECzLSz3Slweyiws7Ix/cZT3TEsrSO5PmoYf7iwt6/3Gc95Gp07E0jRer74HjAmF8/Q50/pj7oelNdzEoycAcA8iF7CZhvNYuyiMI9zd9AB3K/9/zWdIZBc9IdXcj3YlotiFBHdmRkn2NdFxqZqNy0mWlztf7u38IBQpFzsTRIFvOJksYRMYfVmU2p7sYj3/9UXkOVatLn/zcmWvJsA2OzuM2eZ+OEfm1Hzh4dCe1RsX4+HN7Dhore2bcsGg0r0DtG++CWjH6QDednE3kHQ16DEDBeux1Y0exhG5aNkBgnxyE6gFVQoGhZEXvTrPa6pO6jABvNnods6rHnXDibcwXfaVLu8S+X0g=
+# The gh-pages branch is considered "live" and the dev branch deploys to dev
 branches:
   only:
   - gh-pages
+  - dev
 script:
-- bundle exec jekyll build --config  	 	_config.yml,_config_dev.yml
+# This should detect the branch and run the correct build script
+  - if [ "$TRAVIS_BRANCH" = "dev" ]; then bundle exec jekyll build --config _config.yml,_config_dev.yml fi
+  - if [ "$TRAVIS_BRANCH" = "gh-pages" &&  "$TRAVIS_PULL_REQUEST" == "false" ]; then bundle exec jekyll build fi
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_d15196a1bbe0_key -iv $encrypted_d15196a1bbe0_iv
   -in deploy_rsa.enc -out /tmp/deploy_rsa -d
@@ -20,8 +26,15 @@ before_deploy:
 - ssh-add /tmp/deploy\_rsa
 - echo -e "Host $DEPLOY_HOST\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 deploy:
-  provider: script
-  skip_cleanup: true
-  script: rsync -r --quiet --delete-after _site/* $DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_DIRECTORY
-  on:
-    branch: gh-pages
+# DEV server deploy
+  - provider: script
+    skip_cleanup: true
+    script: rsync -r --quiet --delete-after _site/* $DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_DIRECTORY
+    on:
+      branch: dev
+# LIVE server deploy
+  - provider: script
+    skip_cleanup: true
+    script: rsync -r --quiet --delete-after _site/* $DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_DIRECTORY_LIVE
+    on:
+      branch: gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,14 @@ branches:
   - dev
 script:
 # This should detect the branch and run the correct build script
-  - if [ "$TRAVIS_BRANCH" = "dev" ]; then bundle exec jekyll build --config _config.yml,_config_dev.yml fi
-  - if [ "$TRAVIS_BRANCH" = "gh-pages" &&  "$TRAVIS_PULL_REQUEST" == "false" ]; then bundle exec jekyll build fi
+  - |
+    if [ "$TRAVIS_BRANCH" = "dev" ]; then
+      bundle exec jekyll build --config _config.yml,_config_dev.yml;
+    fi
+  - |
+    if [ "$TRAVIS_BRANCH" = "gh-pages" &&  "$TRAVIS_PULL_REQUEST" == "false" ]; then
+      bundle exec jekyll build;
+    fi
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_d15196a1bbe0_key -iv $encrypted_d15196a1bbe0_iv
   -in deploy_rsa.enc -out /tmp/deploy_rsa -d

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,16 @@ description: Resources for the global digital safety training community.
 baseurl: "" # the subpath of your site, e.g. /blog /level-up
 url: "https://level-up.cc" # the base hostname & protocol for your site
 
-exclude: ["node_modules", "gulpfile.js", "package.json"]
+exclude:
+  - gulpfile.js
+  - package.json
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
 include: ["_pages"]
 
 # Build settings

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,4 +14,19 @@ type="text/javascript">window.liveSettings={api_key:"9fa8aae90c864b609e215c01848
   <script type="text/javascript" src="//cdn.transifex.com/live.js"></script> -->
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.1.0/anchor.min.js"></script>
   <script async defer src="https://hypothes.is/embed.js"></script>
+  <!-- Matomo -->
+<script type="text/javascript">
+  var _paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//analytics.level-up.cc/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '1']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 </head>


### PR DESCRIPTION
This activates Travis-based automated testing and deployment to dev.level-up.cc for all changes to the dev branch, and to a (not live but can be) live site on the same eclips.is hosted server. It also activates a matomo-driven analytics site and adds the js tracker in the head include file.