### PR TITLE
Site deployment through Github Actions (prod and dev) 

### DIFF
--- a/.github/workflows/publish-to-dev.yml
+++ b/.github/workflows/publish-to-dev.yml
@@ -57,6 +57,7 @@ jobs:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
           source-directory: './_site'
+          target-directory: 'site'
           destination-github-username: 'tingeber'
           destination-repository-name: 'level-up-dev'
           user-name: 'Level Up Bot'

--- a/.github/workflows/publish-to-dev.yml
+++ b/.github/workflows/publish-to-dev.yml
@@ -9,7 +9,7 @@ name: Deploy dev site
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [ dev ]
+    branches: [ dev-tin ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/publish-to-dev.yml
+++ b/.github/workflows/publish-to-dev.yml
@@ -44,9 +44,11 @@ jobs:
         uses: actions/configure-pages@v3
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build --config _config.yml,_config_dev.yml
         env:
           JEKYLL_ENV: production
+        run: echo "test.level-up.cc" > ./_site/CNAME
+
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v2
@@ -57,11 +59,11 @@ jobs:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
           source-directory: './_site'
-          target-directory: 'site'
-          destination-github-username: 'tingeber'
+          target-directory: '.'
+          destination-github-username: 'levelupcc'
           destination-repository-name: 'level-up-dev'
           user-name: 'Level Up Bot'
-          user-email: tingeber@gmail.com
+          user-email: levelup@joncamfield.com
           target-branch: main
 
   # Deployment job

--- a/.github/workflows/publish-to-dev.yml
+++ b/.github/workflows/publish-to-dev.yml
@@ -1,0 +1,76 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy dev site
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [ dev ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# permissions:
+#   contents: read
+#   pages: write
+#   id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        with:
+          ruby-version: '2.5' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v2
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          # SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: './_site'
+          destination-github-username: 'tingeber'
+          destination-repository-name: 'level-up-dev'
+          user-name: 'Level Up Bot'
+          user-email: tingeber@gmail.com
+          target-branch: main
+
+  # Deployment job
+  # deploy:
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v2

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -1,0 +1,64 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [$default-branch]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        with:
+          ruby-version: '2.5' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v2
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/publish-to-test.yml
+++ b/.github/workflows/publish-to-test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         # Clarify the right baseurl for each branch
-        run: bundle exec jekyll build --baseurl "test.level-up.cc"
+        run: bundle exec jekyll build --config _config.yml,_config_test.yml
         env:
           JEKYLL_ENV: production
         # set cname for gh pages, should match baseurl above

--- a/.github/workflows/publish-to-test.yml
+++ b/.github/workflows/publish-to-test.yml
@@ -1,0 +1,68 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: test site deploy
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [ test ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# permissions:
+#   contents: read
+#   pages: write
+#   id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        with:
+          ruby-version: '2.5' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        # Clarify the right baseurl for each branch
+        run: bundle exec jekyll build --baseurl "test.level-up.cc"
+        env:
+          JEKYLL_ENV: production
+        # set cname for gh pages, should match baseurl above
+        run: echo "test.level-up.cc" > ./_site/CNAME
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v2
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.TEST_DEPLOY_KEY }}
+          # API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: './_site'
+          target-directory: '.'
+          destination-github-username: 'levelupcc'
+          destination-repository-name: 'level-up-test'
+          user-name: 'Level Up Bot'
+          user-email: levelup@joncamfield.com
+          target-branch: main

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem 'jekyll-seo-tag'
 gem 'jemoji'
 gem 'jekyll-readme-index'
 gem 'jekyll-include-cache'
+gem "webrick", "~> 1.8"

--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ Or change it on the fly when you run the serve command with the baseurl of your 
 ```
 jekyll serve --baseurl '' --watch
 ```
+
+# Deployment
+
+## Main site
+Level-Up uses Github Actions to automatically deploy the site on Github Pages whenever there is a change to the repository. The Action it uses is `.github/workflows/publish-to-gh-pages.yml`. It is based on Jekyll's recommended Action configuration: https://jekyllrb.com/docs/continuous-integration/github-actions/. 
+
+## Dev site
+The dev site also uses Github Actions to build whenever there is a change to the `dev` repository, in a slightly more complicated manner:
+- Github Actions runs the `.github/workflows/publish-to-dev.yml` Action that first builds the site, then transfers the directory with static files to another repo, `level-up-dev`
+- `level-up-dev` runs its own Github Action to publish the static files.  

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,8 @@
 title: LevelUp
 description: Resources for the global digital safety training community.
 baseurl: "" # the subpath of your site, e.g. /blog /level-up
-url: "https://level-up.cc" # the base hostname & protocol for your site
+# url: "https://level-up.cc" # the base hostname & protocol for your site
+url: "https://level-up.tin.fyi" # the base hostname & protocol for your site
 
 exclude:
   - gulpfile.js

--- a/_config.yml
+++ b/_config.yml
@@ -9,8 +9,7 @@
 title: LevelUp
 description: Resources for the global digital safety training community.
 baseurl: "" # the subpath of your site, e.g. /blog /level-up
-# url: "https://level-up.cc" # the base hostname & protocol for your site
-url: "https://level-up.tin.fyi" # the base hostname & protocol for your site
+url: "https://level-up.cc" # the base hostname & protocol for your site
 
 exclude:
   - gulpfile.js

--- a/_config_test.yml
+++ b/_config_test.yml
@@ -1,0 +1,2 @@
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "https://test.level-up.cc/" # the base hostname & protocol for your site


### PR DESCRIPTION
Before accepting this PR, make sure the following is set up:

- [x] Revert changes to `config.yml`
- [x] Create a new repo in the `levelupcc` organisation, and set its folder structure [like this repo](https://github.com/tingeber/level-up-dev)
- [x] Set a PAT from a person with write access to both repos, as per this guide: https://cpina.github.io/push-to-another-repository-docs/setup-using-personal-access-token.html#setup-personal-access-token
- [x] `publish-to-dev.yml` line 12 -> change name of repo to the newly created repo
- [x] `publish-to-dev.yml` lines 61-65 -> change relevant data as per guide above  
- [ ] double check `README.md` if repo names are different or if the new paras need more info 

Ca va sans dire but in order for gh-pages to work on both repos, we will also need to change DNS settings for the site. 

I also suggest to double check Matomo setup just to make sure it's not set to only monitor locally-deployed sites. 